### PR TITLE
fix(drawer): change option minWidth prop to width

### DIFF
--- a/src/lib/drawer/Drawer.tsx
+++ b/src/lib/drawer/Drawer.tsx
@@ -91,19 +91,18 @@ type Anchor = 'top' | 'left' | 'bottom' | 'right';
 export interface DrawerProps {
   name: string;
   className?: string;
-  options?: { anchor?: Anchor; minWidth: number };
+  options?: { anchor?: Anchor; width?: number };
 }
 
-export const Drawer: React.FC<DrawerProps> = ({ name, className, children, options: overrides }) => {
+export const Drawer: React.FC<DrawerProps> = ({ name, className, options: overrides, ...props }) => {
+  const { drawerActions, drawerState } = useDrawer();
+  const isOpen = drawerState.active === name;
+
   const options = {
     anchor: 'right' as Anchor,
-    width: 300,
+    width: 320,
     ...overrides
   };
-
-  const { drawerActions, drawerState } = useDrawer();
-
-  const isOpen = drawerState.active === name;
 
   return (
     <MuiDrawer
@@ -111,11 +110,8 @@ export const Drawer: React.FC<DrawerProps> = ({ name, className, children, optio
       anchor={options.anchor}
       open={isOpen}
       onClose={toggleDrawer(name, drawerActions.toggleDrawer)}
-    >
-      {/* TODO: Remove `px` from width to allow setting width with other units.  */}
-      <div className="lc-drawer-content" style={{ width: `${options.width}px` }}>
-        {children}
-      </div>
-    </MuiDrawer>
+      PaperProps={{ className: 'lc-drawer-content', style: { width: `${options.width}px` } }}
+      {...props}
+    />
   );
 };

--- a/src/lib/drawer/drawer.css
+++ b/src/lib/drawer/drawer.css
@@ -1,5 +1,6 @@
 .lc-drawer {
   &-content {
-    padding: 16px;
+    padding: theme('padding.24');
+    max-width: 100%;
   }
 }


### PR DESCRIPTION
I fixed the `minWidth` option issue and also removed the need to have a separate inner `div` for the `lc-drawer-content` by simply moving those attributes to the `PaperProps` prop for the `MuiDrawer` component.