### PR TITLE
fix(tailwind): removing tailwind base to fix header styles across projects that use our component library

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,9 +1,7 @@
 @import './theme/default-theme';
 
-@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';
 
 @import './fonts';
 @import './base';
-
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';


### PR DESCRIPTION
For discussion later, we could also take some of the base styles separately and include them if we think they are helpful.