### PR TITLE
feat(file-upload): add replaceOnly option that doesnt allow you to cl…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdacurry/component-library",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/file-uploader/FileUploader.tsx
+++ b/src/lib/file-uploader/FileUploader.tsx
@@ -25,6 +25,7 @@ import { FileUpload, FileUploaderProps } from './FileUploader.types';
 export const FileUploader: FC<FileUploaderProps> = ({
   name,
   className,
+  replaceOnly,
   maxSize = 1048576, // 1 MB
   minSize,
   // TODO: Consider allowing file extensions in addition to mime-types
@@ -147,6 +148,7 @@ export const FileUploader: FC<FileUploaderProps> = ({
                 <li key={index}>
                   <ButtonUnstyled
                     className="lc-file-uploader-dropzone-file"
+                    disabled={replaceOnly}
                     onClick={event => removeFile(event, index)}
                   >
                     <div className="lc-file-uploader-dropzone-file-thumb">
@@ -182,7 +184,7 @@ export const FileUploader: FC<FileUploaderProps> = ({
         <div className="lc-file-uploader-footer">
           <div className="lc-file-uploader-actions">
             <ButtonAccent onClick={open}>Choose File{multiple && 's'}</ButtonAccent>
-            {((files && files.length > 0) || error) && (
+            {((files && files.length > 0 && !replaceOnly) || error) && (
               <ButtonLink onClick={clearAll} style={{ marginLeft: '12px' }}>
                 Clear {multiple && <>All</>}
               </ButtonLink>

--- a/src/lib/file-uploader/FileUploader.types.ts
+++ b/src/lib/file-uploader/FileUploader.types.ts
@@ -9,6 +9,7 @@ export interface FileUpload extends File {
 export interface FileUploaderProps {
   name: string;
   className?: string;
+  replaceOnly?: boolean;
   maxSize?: number;
   minSize?: number;
   accept?: string[];


### PR DESCRIPTION
…ear files but only override/replace them

I'm working on the icon library for Nybll, where there are default icons, and then you can override each default with another one. I need to be able to clear the overrides so you can go back to the default, but you shouldn't be able to clear the default.

I think this should do what I need it to.