### PR TITLE
enhancement(form): allow unsaved changes modal to accept dynamic content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdacurry/component-library",
-  "version": "2.7.5",
+  "version": "2.8.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/form/Form.tsx
+++ b/src/lib/form/Form.tsx
@@ -12,7 +12,7 @@ import ReactModal from 'react-modal';
 
 export interface FormConfig extends InputConfig {}
 
-export interface UnsavedModalProps extends Partial<ReactModal.Props> {
+export interface UnsavedChangesModalProps extends Partial<ReactModal.Props> {
   modalTitle?: string;
   modalContent?: string;
   modalPrimaryButtonText?: string;
@@ -22,7 +22,7 @@ export interface UnsavedModalProps extends Partial<ReactModal.Props> {
 export interface UnsavedChangesConfig {
   containerQuerySelectorAll?: string;
   targetQuerySelector?: string;
-  modalProps?: UnsavedModalProps;
+  modalProps?: UnsavedChangesModalProps;
 }
 
 export interface FormProps<T> extends FormikConfig<T> {

--- a/src/lib/form/Form.tsx
+++ b/src/lib/form/Form.tsx
@@ -8,13 +8,21 @@ import { InputConfig } from '../inputs/InputBase';
 import './form.css';
 import { Button } from '../buttons/Button';
 import { ButtonPrimary } from '../buttons/ButtonPrimary';
+import ReactModal from 'react-modal';
 
 export interface FormConfig extends InputConfig {}
+
+export interface UnsavedModalProps extends Partial<ReactModal.Props> {
+  modalTitle?: string;
+  modalContent?: string;
+  modalPrimaryButtonText?: string;
+  modalCloseButtonText?: string;
+}
 
 export interface UnsavedChangesConfig {
   containerQuerySelectorAll?: string;
   targetQuerySelector?: string;
-  modalProps?: Partial<ReactModal.Props>;
+  modalProps?: UnsavedModalProps;
 }
 
 export interface FormProps<T> extends FormikConfig<T> {
@@ -122,6 +130,13 @@ export function Form<T>({
     }, 500);
   };
 
+  const {
+    modalCloseButtonText = 'Cancel',
+    modalContent = 'Click continue to abandon your changes and proceed.',
+    modalPrimaryButtonText = 'Continue',
+    modalTitle = 'You have unsaved changes!'
+  } = unsavedChangesConfig.modalProps || {};
+
   return (
     <Formik {...props} initialStatus={{ ...props.initialStatus, formConfig }}>
       {(formikProps: FormikProps<T>) => (
@@ -141,12 +156,14 @@ export function Form<T>({
               closeButton={false}
               {...unsavedChangesConfig?.modalProps}
             >
-              <ModalHeader title="You have unsaved changes!" />
-              <p className="text">Click continue to abandon your changes and continue on.</p>
+              <ModalHeader title={modalTitle} />
+              <p className="text">{modalContent}</p>
               <ModalActions>
                 <div className="flex-spacer" />
-                <Button onClick={handleUnsavedChangesModalClose}>Cancel</Button>
-                <ButtonPrimary onClick={() => handleUnsavedChangesModalContinue(formikProps)}>Continue</ButtonPrimary>
+                <Button onClick={handleUnsavedChangesModalClose}>{modalCloseButtonText}</Button>
+                <ButtonPrimary onClick={() => handleUnsavedChangesModalContinue(formikProps)}>
+                  {modalPrimaryButtonText}
+                </ButtonPrimary>
               </ModalActions>
             </Modal>
           </>


### PR DESCRIPTION
This PR provides the `Form`'s unsaved changes modal the ability to accept replacement values for the header, content, and button labels.