### PR TITLE
enhancement(icon-button): allow passing in custom icon component or iconProps

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,6 +23,10 @@ indent_size = 2
 indent_size = 4
 trim_trailing_whitespace = false
 
+[*.mdx]
+indent_size = 2
+trim_trailing_whitespace = false
+
 [.*rc]
 indent_size = 2
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdacurry/component-library",
-  "version": "5.1.7",
+  "version": "5.2.0",
   "description": "A React component library created by Lambda Curry.",
   "author": "Lambda Curry",
   "license": "ISC",

--- a/packages/ui-components/src/lib/buttons/__documentation__/buttons.stories.mdx
+++ b/packages/ui-components/src/lib/buttons/__documentation__/buttons.stories.mdx
@@ -116,18 +116,19 @@ import './button-story.css';
       {}
     );
     return (
-    <p>{JSON.stringify(state)}</p>
-    <ButtonGroup>
-      <ButtonPrimary className={classNames({ active: state.left })} onClick={() => toggle('left')}>
-        Left
-      </ButtonPrimary>
-      <ButtonPrimary className={classNames({ active: state.middle })} onClick={() => toggle('middle')}>
-        Middle
-      </ButtonPrimary>
-      <ButtonPrimary className={classNames({ active: state.right })} onClick={() => toggle('right')}>
-        Right
-      </ButtonPrimary>
-    </ButtonGroup>)`
+      <p>{JSON.stringify(state)}</p>
+      <ButtonGroup>
+        <ButtonPrimary className={classNames({ active: state.left })} onClick={() => toggle('left')}>
+          Left
+        </ButtonPrimary>
+        <ButtonPrimary className={classNames({ active: state.middle })} onClick={() => toggle('middle')}>
+          Middle
+        </ButtonPrimary>
+        <ButtonPrimary className={classNames({ active: state.right })} onClick={() => toggle('right')}>
+          Right
+        </ButtonPrimary>
+      </ButtonGroup>
+    )`
         }
       }
     }}

--- a/packages/ui-components/src/lib/icon-button/IconButton.tsx
+++ b/packages/ui-components/src/lib/icon-button/IconButton.tsx
@@ -1,20 +1,21 @@
-import React, { FC, forwardRef } from 'react';
+import React, { FC, forwardRef, ReactNode } from 'react';
 import classNames from 'classnames';
-import { Icon, IconNames } from '../icon/Icon';
+import { Icon, IconNames, IconProps } from '../icon/Icon';
 import { ButtonProps } from '../buttons/ButtonBase';
 import { ButtonStyled } from '../buttons/ButtonStyled';
 import './icon-button.css';
 
 export interface IconButtonProps extends ButtonProps {
-  icon: IconNames;
+  icon: IconNames | ReactNode;
+  iconProps?: IconProps;
 }
 
-export const IconButton: FC<IconButtonProps> = forwardRef(({ className, icon, ...props }, ref) => (
+export const IconButton: FC<IconButtonProps> = forwardRef(({ className, icon, iconProps, ...props }, ref) => (
   <ButtonStyled
     {...props}
     className={classNames([`lc-icon-button`, `focus-visible:lc-ring-gray-lighter`], className)}
     ref={ref}
   >
-    <Icon name={icon} />
+    {typeof icon === 'string' ? <Icon name={icon} {...iconProps} /> : icon}
   </ButtonStyled>
 ));

--- a/packages/ui-components/src/lib/icon-button/icon-button-documentation/icon-button.stories.mdx
+++ b/packages/ui-components/src/lib/icon-button/icon-button-documentation/icon-button.stories.mdx
@@ -15,10 +15,10 @@ import './icon-button-story.css';
     parameters={{
       docs: {
         source: {
-          code: dedent`<IconButton key={iconName} icon={iconName} />
-          <div className="lc-my-4 lc-text-primary">
-            <IconButton className="match-text-color" icon="eye" />
-          </div>`
+          code: dedent`<IconButton key={iconName} icon={iconName} />\n
+<div className="lc-my-4 lc-text-primary">
+  <IconButton className="match-text-color" icon="eye" />
+</div>`
         }
       }
     }}


### PR DESCRIPTION
* Allow passing `iconProps` to `IconButton` component.
* Allow passing custom `icon` as `ReactNode` to `IconButton` component.

Closes #100